### PR TITLE
Add unofficial php library

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The official iOS client library is [yelp-ios](https://github.com/Yelp/yelp-ios).
 * [tonybadguy/yelp-fusion](https://github.com/tonybadguy/yelp-fusion)
 * [danieljin/yelpv3](https://github.com/danieljin/yelpv3)
 
+#### PHP
+* [stevenmaguire/yelp-php](https://github.com/stevenmaguire/yelp-php)
+
 ## Code samples
 This Github repo includes several small code samples:
 * [Node.js](https://github.com/Yelp/yelp-fusion/tree/master/fusion/node)


### PR DESCRIPTION
Greetings! I maintain a well tested PHP package that wraps the Yelp API. It has current support of the v3 Fusion API. I would like to add it to the list of packages that are present in this repo. 

Additionally, purely as an FYI, I also maintain the Yelp OAuth2 php package that facilitates authenticated requests to the Yelp API. https://github.com/stevenmaguire/oauth2-yelp