### PR TITLE
modified sample.py in order to be compatible with Yelp Fusion 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 *.swp
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/fusion/python/requirements.txt
+++ b/fusion/python/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.12.1
+requests==2.18.4


### PR DESCRIPTION
<b>Explanation for this Pull Request</b>
I wanted to make a Yelp App and tried using the sample.py but it didn't work. The problem came from trying to get a "bearer_token".
I think the sample.py was outdated, and did not function with the new Yelp Fusion API. sample.py needed client_secret, and one no longer gets one from making an app. I changed sample to no longer use the "client_ID" and "client_secret" and now it only uses the API Key that one gets from creating the app. <b>sample.py is now Fully Funcitonal</b>

<b>Changes made to .gitignore</b>
I added virtual environments to the .gitignore so I could make a virtual env inside the git repo file in my computer and test the sample.py from there.

<b>Changes made to requirements.txt</b>
I updated the requirements.txt to have the latest version of requests the requests library. I thought that might have been the problem, before figuring out that the Yelp API no longer used OAuth, but it turned out that wasn't it.

<b>Changes made to sample.py</b>
Updated all documentation to be compatible with the new functions, and also the new Yelp API.
I got rid of the obtain_bearer_token function, since the new Yelp Fusion API Get requests no longer require it. Now they just need the App API Key.