### PR TITLE
Add yelpapi as unofficial Python implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The official iOS client library is [yelp-ios](https://github.com/Yelp/yelp-ios).
 #### Swift
 * [chrisdhaan/CDYelpFusionKit](https://github.com/chrisdhaan/CDYelpFusionKit)
 
+#### Python
+* [gfairchild/yelpapi](https://github.com/gfairchild/yelpapi)
+
 ## Code samples
 This Github repo includes several small code samples:
 * [Node.js](https://github.com/Yelp/yelp-fusion/tree/master/fusion/node)


### PR DESCRIPTION
I've been developing a Python implementation of the Yelp API since v2 at https://github.com/gfairchild/yelpapi. It's current with all of the latest Fusion features (including all 10 endpoints and the use of API keys for authentication). To my knowledge, it's the current standard for a complete implementation of the Fusion API in Python. It would be nice if the readme included a link to it.