### PR TITLE
Add yelpr as unofficial R implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The official iOS client library is [yelp-ios](https://github.com/Yelp/yelp-ios).
 #### Swift
 * [chrisdhaan/CDYelpFusionKit](https://github.com/chrisdhaan/CDYelpFusionKit)
 
+#### R
+* [OmaymaS/yelpr](https://github.com/OmaymaS/yelpr)
+
 ## Code samples
 This Github repo includes several small code samples:
 * [Node.js](https://github.com/Yelp/yelp-fusion/tree/master/fusion/node)


### PR DESCRIPTION
I have been working on an R implementation; [yelpr](https://github.com/OmaymaS/yelpr)  for Yelp Fusion API. 
It would be good to have it in the unofficial interfaces list.