### PR TITLE
running bundle does not work

### DIFF
--- a/fusion/ruby/readme.md
+++ b/fusion/ruby/readme.md
@@ -19,6 +19,8 @@ $ cd yelp-fusion/fusion/ruby
 Install the dependences:
 
 ```
+$ gem install ruby
+$ gem install bundle 
 $ bundle 
 ```
 


### PR DESCRIPTION
Kept getting the following error 
-bash: bundle: command not found
update readme to install ruby and then bundle